### PR TITLE
add DAG-based DLT platforms

### DIFF
--- a/blockchain-tech-map.gv
+++ b/blockchain-tech-map.gv
@@ -2,6 +2,7 @@
 digraph {    
     root [label="Decentralized Platforms"] 
     blockchains [label="Blockchains"]
+    dags [label="DAGs"]
     infra [label="Infrastructure"]
     defi [label="DeFi"]
 
@@ -62,6 +63,9 @@ digraph {
     starkex [label="StarkEx", href="https://starkware.co/product/starkex/"]
     xdai [label="xDai", href="https://www.xdaichain.com/"]
     zksync [label="zkSync", href="https://zksync.io/"]
+
+    iota [label="IOTA", href="https://www.iota.org/"]
+    hedera [label="Hedera Hashgraph", href="https://hedera.com/"]
 
     analytics [label="Analytics"]
     oracles [label="Oracles"]
@@ -150,7 +154,7 @@ digraph {
     cover [label="Cover", href="https://www.coverprotocol.com/"]
     nexus [label="Nexus Mutual", href="https://nexusmutual.io/"]
     opium [label="Opium", href="https://opium.finance/"]
-    
+
     root -> blockchains
     
     blockchains -> layer1
@@ -208,6 +212,10 @@ digraph {
     sidechain -> xdai
     validium -> loopring
     validium -> starkex
+
+    root -> dags
+    dags -> iota
+    dags -> hedera
 
     root -> defi
     defi -> dex


### PR DESCRIPTION
This is a proposal to add DAG-based DLT platforms that are not necessarily blockchains, for example, IOTA and Hedera Hashgraph. I find Hedera Hashgraph quiet interesting for their concensus algorithm using gossip-about-gossip and virtual voting, and their "hybrid" approach to building a public network with permission-ed nodes run by the Hedera Governing Council. The code is open review, as opposed to open source. And they claim to be aBFT, with a mathematical proof! I would love to hear what you think of them.